### PR TITLE
New page: Installing Dependences Guide

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ Makefile*
 # QtCtreator CMake
 CMakeLists.txt.user*
 
+# Visual Studio Code
+*.vs

--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -1,13 +1,12 @@
 # Installing Dependencies
 
-Here you can find how to install Clevit dependencies to your Operation System
+Here you can find how to install Clevit dependencies to your Operation System.
 
 ## Installing dependencies on Arch Linux, Antergos, Manjaro ...
 `pacaur -Syy cmake qt5-base qt5-translations qt5-graphicaleffects xdg-utils qt5-quickcontrols2 qt5-quickcontrols qt5-declarative libevent openssl`
 
 ## Installing dependencies on Ubuntu , Linux Mint, Debian ...
 `sudo apt-get install build-essential libssl-dev make cmake qtdeclarative5-dev qml-module-qtquick-controls qt5-default openssl`
-
 
 ## Installing dependencies on RedHat, Fedora ...
 `sudo dnf install automake gcc gcc-c++ kernel-devel make cmake qt5 qt5-devel qt5-qtbase qt5-qtbase-devel qt5-qtdeclarative qt5-qtdeclarative-devel openssl`

--- a/INSTALLING.md
+++ b/INSTALLING.md
@@ -1,0 +1,13 @@
+# Installing Dependencies
+
+Here you can find how to install Clevit dependencies to your Operation System
+
+## Installing dependencies on Arch Linux, Antergos, Manjaro ...
+`pacaur -Syy cmake qt5-base qt5-translations qt5-graphicaleffects xdg-utils qt5-quickcontrols2 qt5-quickcontrols qt5-declarative libevent openssl`
+
+## Installing dependencies on Ubuntu , Linux Mint, Debian ...
+`sudo apt-get install build-essential libssl-dev make cmake qtdeclarative5-dev qml-module-qtquick-controls qt5-default openssl`
+
+
+## Installing dependencies on RedHat, Fedora ...
+`sudo dnf install automake gcc gcc-c++ kernel-devel make cmake qt5 qt5-devel qt5-qtbase qt5-qtbase-devel qt5-qtdeclarative qt5-qtdeclarative-devel openssl`

--- a/INSTALLING_DEPENDENCIES_GUIDE.md
+++ b/INSTALLING_DEPENDENCIES_GUIDE.md
@@ -2,6 +2,20 @@
 
 Here you can find how to install Clevit dependencies to your Operation System.
 
+# Dependencies
+
+You need install this dependencies before install Clevit
+
+* cmake 2.8.11 or a newer version - https://cmake.org/
+
+* make
+
+* Qt5 - https://www.qt.io/
+
+* OpenSSL - https://www.openssl.org/ but the easiest but unofficial way for Windows is this:  https://slproweb.com/download/Win32OpenSSL-1_1_0f.exe
+
+---
+
 ## Installing dependencies on Arch Linux, Antergos, Manjaro ...
 `pacaur -Syy cmake qt5-base qt5-translations qt5-graphicaleffects xdg-utils qt5-quickcontrols2 qt5-quickcontrols qt5-declarative libevent openssl`
 

--- a/INSTALLING_DEPENDENCIES_GUIDE.md
+++ b/INSTALLING_DEPENDENCIES_GUIDE.md
@@ -1,4 +1,4 @@
-# Installing Dependencies
+# Installing Dependencies Guide
 
 Here you can find how to install Clevit dependencies to your Operation System.
 
@@ -10,3 +10,6 @@ Here you can find how to install Clevit dependencies to your Operation System.
 
 ## Installing dependencies on RedHat, Fedora ...
 `sudo dnf install automake gcc gcc-c++ kernel-devel make cmake qt5 qt5-devel qt5-qtbase qt5-qtbase-devel qt5-qtdeclarative qt5-qtdeclarative-devel openssl`
+
+## MacOS & Windows
+Check the official web sites

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You need install this dependencies before install Clevit
 
 * OpenSSL - https://www.openssl.org/ but the easiest but unofficial way for Windows is this:  https://slproweb.com/download/Win32OpenSSL-1_1_0f.exe
 
-To see how to install those dependencies to your specific operation system check the [Instalation guide](INSTALLING.md).
+To see how to install those dependencies to your specific operation system check the [Installing Dependences Guide](INSTALLING_DEPENDENCIES_GUIDE.md).
 
 # Install Clevit - Qmake method
 

--- a/README.md
+++ b/README.md
@@ -11,17 +11,6 @@
 * Add a smart spell checker
 
 # Dependencies
-
-You need install this dependencies before install Clevit
-
-* cmake 2.8.11 or a newer version - https://cmake.org/
-
-* make
-
-* Qt5 - https://www.qt.io/
-
-* OpenSSL - https://www.openssl.org/ but the easiest but unofficial way for Windows is this:  https://slproweb.com/download/Win32OpenSSL-1_1_0f.exe
-
 To see how to install those dependencies to your specific operation system check the [Installing Dependences Guide](INSTALLING_DEPENDENCIES_GUIDE.md).
 
 # Install Clevit - Qmake method

--- a/README.md
+++ b/README.md
@@ -22,15 +22,7 @@ You need install this dependencies before install Clevit
 
 * OpenSSL - https://www.openssl.org/ but the easiest but unofficial way for Windows is this:  https://slproweb.com/download/Win32OpenSSL-1_1_0f.exe
 
-## Installing dependencies on Arch Linux, Antergos, Manjaro ...
-`pacaur -Syy cmake qt5-base qt5-translations qt5-graphicaleffects xdg-utils qt5-quickcontrols2 qt5-quickcontrols qt5-declarative libevent openssl`
-
-## Installing dependencies on Ubuntu , Linux Mint, Debian ...
-`sudo apt-get install build-essential libssl-dev make cmake qtdeclarative5-dev qml-module-qtquick-controls qt5-default openssl`
-
-
-## Installing dependencies on RedHat, Fedora ...
-`sudo dnf install automake gcc gcc-c++ kernel-devel make cmake qt5 qt5-devel qt5-qtbase qt5-qtbase-devel qt5-qtdeclarative qt5-qtdeclarative-devel openssl`
+To see how to install those dependencies to your specific operation system check the [Instalation guide](INSTALLING.md).
 
 # Install Clevit - Qmake method
 


### PR DESCRIPTION
Fixes #106 

Changes
- Added a new file called Installing dependences guide
- Remove dependence description of README
- Added a reference to the Installing dependeces guide page in the README

To see how it is, check my fork [k30v1n/Clevit](https://github.com/k30v1n/Clevit)
